### PR TITLE
Update delegateMonitor.feature

### DIFF
--- a/features/delegateMonitor.feature
+++ b/features/delegateMonitor.feature
@@ -102,7 +102,7 @@ Feature: Delegate Monitor
   Scenario: latest votes should link to transaction
     Given I'm on page "/delegateMonitor"
     When I click link on row no. 1 cell no. 2 of "votes" table
-    Then I should be on page "/tx/11267727202420741572"
+    Then I should be on page "/explorer/tx/11267727202420741572"
 
   Scenario: newest delegates should link to delegate
     Given I'm on page "/delegateMonitor"
@@ -112,7 +112,7 @@ Feature: Delegate Monitor
   Scenario: newest delegates should link to transaction
     Given I'm on page "/delegateMonitor"
     When I click link on row no. 1 cell no. 2 of "registrations" table
-    Then I should be on page "/tx/2535943083975103126"
+    Then I should be on page "/explorer/tx/2535943083975103126"
 
   Scenario: active delegates should link to delegate
     Given I'm on page "/delegateMonitor"


### PR DESCRIPTION
### What was the problem?
When clicking on "Transaction" links of the delegate monitor under "Latest Votes" and "Newest Delegates" the link is missing the necessary "/explore/" addition to the URL.
### How did I fix it?
Adding "/explorer" to "/tx/[transaction number]" to lines 105 and 115 of delegateMonitor.feature
### How to test it?
Install Shift Explorer from TerraBellus/shift-explorer and check the links function correctly
### Review checklist
- All new code follows best practices
